### PR TITLE
Simplify candle API route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/react": "^18.2.24",
         "eslint": "^8.57.0",
         "eslint-config-next": "^15.0.0-canary.56",
+        "eslint-config-prettier": "^10.1.5",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.1",
         "typescript": "^5.5.0"
@@ -4169,6 +4170,22 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
+      "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/jest": "^29.5.5",
     "eslint": "^8.57.0",
     "eslint-config-next": "^15.0.0-canary.56",
+    "eslint-config-prettier": "^10.1.5",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "typescript": "^5.5.0"

--- a/src/__tests__/indicators.test.ts
+++ b/src/__tests__/indicators.test.ts
@@ -3,15 +3,17 @@ import originalConfig from '@/config/signals.json';
 
 function loadSignal(cfg = originalConfig) {
   jest.resetModules();
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
   const config = require('@/config/signals.json');
   Object.assign(config, cfg);
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
   return require('@/lib/signal').getSignal as typeof import('@/lib/signal').getSignal;
 }
 import type { Candle } from '@/lib/types';
 
 function genCandles(prices: number[], volume: number | number[] = 100): Candle[] {
   return prices.map((p, i) => ({
+    time: i,
     open: p,
     high: p,
     low: p,

--- a/src/app/api/candles/route.ts
+++ b/src/app/api/candles/route.ts
@@ -1,60 +1,16 @@
-import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
-import { Candle } from '@/lib/types';
+import { getBinanceCandles } from '@/lib/binance';
 
-const CACHE_KEY = 'candles';
-let cached: { data: Candle[]; ts: number } | undefined;
-const CACHE_TTL = 30_000; // 30s
+export const revalidate = 60;
 
-async function fetchBinance(): Promise<Candle[]> {
-  const url =
-    'https://api.binance.com/api/v3/klines?symbol=BTCUSDT&interval=5m&limit=120';
-  const res = await fetch(url, { next: { revalidate: CACHE_TTL / 1000 } });
-  const json = (await res.json()) as any[];
-  return json.map((k) => ({
-    open: +k[1],
-    high: +k[2],
-    low: +k[3],
-    close: +k[4],
-    volume: +k[5],
-  }));
-}
-
-async function fetchCoinGecko(): Promise<Candle[]> {
-  const url =
-    'https://api.coingecko.com/api/v3/coins/bitcoin/ohlc?vs_currency=usd&days=1';
-  const res = await fetch(url, { next: { revalidate: CACHE_TTL / 1000 } });
-  const arr = (await res.json()) as any[];
-  // last 120 5-min candles (CoinGecko returns ms timestamp + ohlc, no volume)
-  return arr.slice(-120).map((k) => ({
-    open: +k[1],
-    high: +k[2],
-    low: +k[3],
-    close: +k[4],
-    volume: 1,
-  }));
-}
-
-async function fetchCandles(): Promise<Candle[]> {
+export async function GET() {
   try {
-    const data = await fetchBinance();
-    if (Array.isArray(data) && data.length) return data;
-  } catch {
-    // fallthrough to gecko
-  }
-  return fetchCoinGecko();
-}
-
-export async function GET(_req: NextRequest) {
-  if (cached && Date.now() - cached.ts < CACHE_TTL) {
-    return NextResponse.json(cached.data);
-  }
-  try {
-    const candles = await fetchCandles();
-    cached = { data: candles, ts: Date.now() };
+    const candles = await getBinanceCandles();
     return NextResponse.json(candles);
-  } catch (err) {
-    console.error('candles api error', err);
-    return new NextResponse('error fetching candles', { status: 500 });
+  } catch {
+    return NextResponse.json(
+      { error: 'upstream_unavailable' },
+      { status: 502 }
+    );
   }
 }

--- a/src/components/MarketChart.tsx
+++ b/src/components/MarketChart.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 
 declare global {
   interface Window {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     TradingView: any;
   }
 }

--- a/src/lib/binance.ts
+++ b/src/lib/binance.ts
@@ -1,0 +1,26 @@
+import type { Candle } from './types';
+
+const BASE_URL = process.env.BINANCE_BASE_URL ?? 'https://api.binance.com';
+let lastCall = 0;
+
+export async function getBinanceCandles(limit = 100): Promise<Candle[]> {
+  if (process.env.NODE_ENV === 'development' && Date.now() - lastCall < 5000) {
+    throw new Error('binance_rate_limit');
+  }
+  lastCall = Date.now();
+
+  const url = `${BASE_URL}/api/v3/klines?symbol=BTCUSDT&interval=5m&limit=${limit}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('fetch_failed');
+  // Binance returns [ open time, open, high, low, close, volume, ... ]
+  const arr = (await res.json()) as unknown[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return arr.map((c: any) => ({
+    time: c[0] / 1000,
+    open: +c[1],
+    high: +c[2],
+    low: +c[3],
+    close: +c[4],
+    volume: +c[5],
+  }));
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,5 @@
 export interface Candle {
+  time: number;
   open: number;
   high: number;
   low: number;


### PR DESCRIPTION
## Summary
- implement `getBinanceCandles` util for fetching candles from Binance
- extend `Candle` type with `time`
- simplify `/api/candles` route to call `getBinanceCandles` and handle errors
- adjust tests and components for lint rules
- add eslint-config-prettier for linting

## Testing
- `npx next lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684afc138fe88323874f810093ceaaaf