### PR TITLE
Add binance fetch test

### DIFF
--- a/src/__tests__/binance.test.ts
+++ b/src/__tests__/binance.test.ts
@@ -1,0 +1,38 @@
+import { getBinanceCandles } from '@/lib/binance';
+
+describe('getBinanceCandles', () => {
+  beforeEach(() => {
+    const mockData = Array.from({ length: 100 }, (_, i) => [
+      i * 1000,
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+    ]);
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: async () => mockData,
+      })
+    ) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    // @ts-ignore
+    delete global.fetch;
+  });
+
+  it('maps response to candle objects', async () => {
+    const candles = await getBinanceCandles();
+    expect(candles).toHaveLength(100);
+    const sample = candles[0];
+    expect(sample).toHaveProperty('time');
+    expect(sample).toHaveProperty('open');
+    expect(sample).toHaveProperty('high');
+    expect(sample).toHaveProperty('low');
+    expect(sample).toHaveProperty('close');
+    expect(sample).toHaveProperty('volume');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for `getBinanceCandles` and mock global `fetch`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684b02ebbee4832394aa3165275c0e1f