### PR TITLE
Add short dataset case for rsi test

### DIFF
--- a/src/__tests__/indicators.test.ts
+++ b/src/__tests__/indicators.test.ts
@@ -33,6 +33,11 @@ describe('indicators', () => {
   it('calculates rsi correctly', () => {
     expect(rsi14(candles)).toBeCloseTo(100, 0); // All prices rising = RSI 100
   });
+
+  it('returns NaN for short datasets', () => {
+    const shortCandles = genCandles(Array.from({ length: 10 }, (_, i) => i + 1));
+    expect(rsi14(shortCandles)).toBeNaN();
+  });
   
   it('calculates vwap correctly', () => {
     expect(vwap(candles)).toBeCloseTo(15.5, 1);


### PR DESCRIPTION
## Summary
- check that rsi14 returns NaN for datasets under 15 candles

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684b0385df7c8323826466b05cdd3c21