### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ npm run dev
 
 ## Tests
 
+```bash
+npm run test
 ```
-npm test
-```
+
+## Binance API
+
+Binance limits requests to **1200 per minute**. The `/api/candles` route caches
+responses for 60 seconds, so the app stays well below this limit.


### PR DESCRIPTION
## Summary
- show how to run the tests via `npm run test`
- add Binance API rate limit note and mention 60-second cache

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_684b04e6cdec8323b823bbfd3ecece4b