### PR TITLE
Update binance base url handling

### DIFF
--- a/src/__tests__/binance.test.ts
+++ b/src/__tests__/binance.test.ts
@@ -22,6 +22,7 @@ describe('getBinanceCandles', () => {
   afterEach(() => {
     // @ts-expect-error - jest adds fetch during tests
     delete global.fetch;
+    delete process.env.BINANCE_BASE_URL;
   });
 
   it('maps response to candle objects', async () => {
@@ -34,5 +35,13 @@ describe('getBinanceCandles', () => {
     expect(sample).toHaveProperty('low');
     expect(sample).toHaveProperty('close');
     expect(sample).toHaveProperty('volume');
+  });
+
+  it('uses custom base url when provided', async () => {
+    process.env.BINANCE_BASE_URL = 'https://custom.com/api/v3';
+    await getBinanceCandles();
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://custom.com/api/v3/klines?symbol=BTCUSDT&interval=5m&limit=100'
+    );
   });
 });

--- a/src/lib/binance.ts
+++ b/src/lib/binance.ts
@@ -8,9 +8,12 @@ export async function getBinanceCandles(limit = 100): Promise<Candle[]> {
   }
   lastCall = Date.now();
 
-  const url =
-    process.env.BINANCE_BASE_URL ??
-    `https://api.binance.com/api/v3/klines?symbol=BTCUSDT&interval=5m&limit=${limit}`;
+  const base =
+    (process.env.BINANCE_BASE_URL ?? 'https://api.binance.com/api/v3').replace(
+      /\/$/,
+      ''
+    );
+  const url = `${base}/klines?symbol=BTCUSDT&interval=5m&limit=${limit}`;
   const res = await fetch(url);
   if (!res.ok) throw new Error('fetch_failed');
   // Binance returns [ open time, open, high, low, close, volume, ... ]


### PR DESCRIPTION
## Summary
- fix `getBinanceCandles` to build URL from base path
- add regression test for custom base URL

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_b_684b18684e148323a95ac051b362ceed