### PR TITLE
Add Node version enforcement

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary
- ensure runtime is Node 18 or newer using `engines` field in `package.json`

## Testing
- `npm run test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b3126ff6483238d5930a3007e4193