### PR TITLE
Improve fetch error handling

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,10 +42,16 @@ function useAutoRefresh<T>(fetcher: () => Promise<T>, interval = 15_000) {
 async function fetchCandles() {
   try {
     const res = await fetch('/api/candles');
-    if (!res.ok) throw new Error('api error');
+    if (!res.ok) {
+      const err = new Error('api error') as Error & { status?: number };
+      err.status = res.status;
+      throw err;
+    }
     return (await res.json()) as Candle[];
-  } catch {
-    throw new Error('Data unavailable \u2014 retrying');
+  } catch (err: unknown) {
+    const status = (err as { status?: number })?.status;
+    const statusMsg = status ? ` (status ${status})` : '';
+    throw new Error(`Data unavailable \u2014 retrying${statusMsg}`);
   }
 }
 


### PR DESCRIPTION
## Summary
- show HTTP status on fetch errors when available

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_684c1a46f7648323b2e5beb408a51e31