### PR TITLE
Fix timestamp precision for market data

### DIFF
--- a/src/__tests__/market-data.test.ts
+++ b/src/__tests__/market-data.test.ts
@@ -1,0 +1,22 @@
+import { GET } from '@/app/api/market-data/route';
+
+describe('market-data API', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() => Promise.reject(new Error('fail')) ) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - jest adds fetch during tests
+    delete global.fetch;
+  });
+
+  it('returns candle timestamps in seconds', async () => {
+    const req = new Request('http://localhost/api/market-data');
+    const res = await GET(req);
+    const data = await res.json();
+    expect(Array.isArray(data.candles)).toBe(true);
+    const sample = data.candles[0];
+    expect(sample.time).toBeLessThan(1e11); // should be seconds, not ms
+    expect(sample.closeTime).toBe(sample.time + 5 * 60);
+  });
+});

--- a/src/app/api/market-data/route.ts
+++ b/src/app/api/market-data/route.ts
@@ -4,13 +4,13 @@ import { Candle, OrderBookData, Trade } from '@/lib/types';
 // Format raw Binance candle data to our app's format
 function formatCandles(rawCandles: any[]): Candle[] {
   return rawCandles.map(candle => ({
-    time: Number(candle[0]),
+    time: Number(candle[0]) / 1000,
     open: Number(candle[1]),
     high: Number(candle[2]),
     low: Number(candle[3]),
     close: Number(candle[4]),
     volume: Number(candle[5]),
-    closeTime: Number(candle[6]),
+    closeTime: Number(candle[6]) / 1000,
     quoteAssetVolume: Number(candle[7]),
     trades: Number(candle[8]),
     takerBuyBaseAssetVolume: Number(candle[9]),
@@ -41,13 +41,13 @@ function formatTrades(rawTrades: any[]): Trade[] {
 
 // Generate mock data when Binance API is unavailable
 function generateMockData(symbol: string) {
-  const now = Date.now();
+  const now = Math.floor(Date.now() / 1000);
   const basePrice = 38000; // For BTCUSDT
   
   // Generate mock candles
   const mockCandles: Candle[] = [];
   for (let i = 99; i >= 0; i--) {
-    const timeOffset = i * 5 * 60 * 1000; // 5 minutes per candle
+    const timeOffset = i * 5 * 60; // 5 minutes per candle (seconds)
     const time = now - timeOffset;
     const volatility = Math.random() * 100 - 50;
     const close = basePrice + volatility;
@@ -62,7 +62,7 @@ function generateMockData(symbol: string) {
       low,
       close,
       volume: Math.random() * 10 + 1,
-      closeTime: time + 5 * 60 * 1000,
+      closeTime: time + 5 * 60,
       quoteAssetVolume: Math.random() * 100000 + 10000,
       trades: Math.floor(Math.random() * 100 + 50),
       takerBuyBaseAssetVolume: Math.random() * 5 + 0.5,


### PR DESCRIPTION
## Summary
- return candle timestamps in seconds
- generate mock candles with second precision
- test `/api/market-data` candle timestamps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684c51427fc0832386826d60fe97af08