### PR TITLE
Add macro context API

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,33 @@ Binance limits requests to **1200 per minute**. The `/api/candles` route caches 
 | LunarCrush | 25 reqs/hour | Hour | OK: Social sentiment (cache for 5-10 mins) |
 | FMP | 250 reqs/day | Day | LIMITED: One-time data loads (24h cache) |
 | Alpha Vantage | 25 reqs/day | Day | NOT RECOMMENDED: Too limited |
+
+## Macro Context API
+
+The `/api/macro-context` route provides a compact snapshot of key U.S. macroeconomic indicators. Results are cached for 24 hours to minimize requests to the FRED API.
+
+Example:
+
+```bash
+curl http://localhost:3000/api/macro-context
+```
+
+Response
+
+```json
+{
+  "updated": 1710000000000,
+  "data": {
+    "fedFundsRate": { "date": "2024-05-01", "value": 5.25, "change": 0.25, "trend": "up" },
+    "cpi": { "date": "2024-05-01", "value": 300.1, "change": 1.0, "trend": "up" },
+    "unemployment": { "date": "2024-05-01", "value": 3.9, "change": 0.1, "trend": "up" }
+  },
+  "insights": {
+    "fedFunds": "Rates rising",
+    "inflation": "Inflation increasing",
+    "employment": "Job market weakening"
+  }
+}
+```
+
+Use these metrics for additional trading context alongside technical signals.

--- a/TASKS.md
+++ b/TASKS.md
@@ -355,7 +355,7 @@ Goal: Create a minimalist, high-performance decision support system optimized fo
   • Include 5-minute cache with revalidation strategy (12 calls/hour, well under 25/hour limit)
   • Add trend detection between subsequent calls to identify sentiment shifts
 
-11.3 Create `app/api/macro-context/route.ts`
+11.3 Create `app/api/macro-context/route.ts` — DONE
   • GET → Key macroeconomic indicators from FRED API
   • Implement 24-hour caching strategy for these slow-changing metrics
   • Include daily summary insights based on latest values

--- a/src/__tests__/macro-context.test.ts
+++ b/src/__tests__/macro-context.test.ts
@@ -1,0 +1,43 @@
+import { GET } from '@/app/api/macro-context/route';
+import fs from 'fs';
+import path from 'path';
+
+const CACHE_DIR = path.join(process.cwd(), '.cache');
+const CACHE_FILE = path.join(CACHE_DIR, 'macro_context.json');
+
+describe('macro-context API', () => {
+  beforeEach(() => {
+    if (!fs.existsSync(CACHE_DIR)) fs.mkdirSync(CACHE_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    // @ts-expect-error jest adds fetch
+    delete global.fetch;
+    if (fs.existsSync(CACHE_FILE)) fs.unlinkSync(CACHE_FILE);
+  });
+
+  it('returns summarized macro data on success', async () => {
+    const fed = { observations: [ { date: '2024-05-01', value: '5' }, { date: '2024-04-01', value: '4.5' } ] };
+    const cpi = { observations: [ { date: '2024-05-01', value: '300' }, { date: '2024-04-01', value: '299' } ] };
+    const unemp = { observations: [ { date: '2024-05-01', value: '3.9' }, { date: '2024-04-01', value: '3.8' } ] };
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => fed })
+      .mockResolvedValueOnce({ ok: true, json: async () => cpi })
+      .mockResolvedValueOnce({ ok: true, json: async () => unemp }) as unknown as typeof fetch;
+
+    const res = await GET(new Request('http://localhost/api/macro-context'));
+    const data = await res.json();
+    expect(data.data.fedFundsRate.value).toBe(5);
+    expect(data.insights.fedFunds).toMatch(/rising/);
+  });
+
+  it('falls back to cache when fetch fails', async () => {
+    const cached = { cached: true };
+    fs.writeFileSync(CACHE_FILE, JSON.stringify({ timestamp: Date.now(), data: cached }));
+
+    global.fetch = jest.fn(() => Promise.reject(new Error('fail'))) as unknown as typeof fetch;
+    const res = await GET(new Request('http://localhost/api/macro-context'));
+    const json = await res.json();
+    expect(json.cached).toBe(true);
+  });
+});

--- a/src/app/api/macro-context/route.ts
+++ b/src/app/api/macro-context/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+
+const CACHE_DIR = path.join(process.cwd(), '.cache');
+const CACHE_FILE = path.join(CACHE_DIR, 'macro_context.json');
+const CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
+
+if (!fs.existsSync(CACHE_DIR)) {
+  fs.mkdirSync(CACHE_DIR, { recursive: true });
+}
+
+interface FredResponse {
+  observations: { date: string; value: string }[];
+}
+
+function loadCache() {
+  try {
+    if (fs.existsSync(CACHE_FILE)) {
+      const raw = fs.readFileSync(CACHE_FILE, 'utf8');
+      const parsed = JSON.parse(raw);
+      if (Date.now() - parsed.timestamp < CACHE_TTL) {
+        return parsed.data;
+      }
+    }
+  } catch (e) {
+    console.error('Failed to load macro cache:', e);
+  }
+  return null;
+}
+
+function saveCache(data: any) {
+  try {
+    fs.writeFileSync(
+      CACHE_FILE,
+      JSON.stringify({ timestamp: Date.now(), data }),
+      'utf8'
+    );
+  } catch (e) {
+    console.error('Failed to save macro cache:', e);
+  }
+}
+
+async function fetchSeries(id: string): Promise<FredResponse> {
+  const key = process.env.FRED_API_KEY || '';
+  const url =
+    `https://api.stlouisfed.org/fred/series/observations?series_id=${id}` +
+    `&api_key=${key}&file_type=json&sort_order=desc&limit=2`;
+  const res = await fetch(url, { next: { revalidate: 86400 } });
+  if (!res.ok) throw new Error(`FRED ${id} status ${res.status}`);
+  return (await res.json()) as FredResponse;
+}
+
+export async function GET() {
+  try {
+    const [fed, cpi, unemp] = await Promise.all([
+      fetchSeries('FEDFUNDS'),
+      fetchSeries('CPIAUCSL'),
+      fetchSeries('UNRATE')
+    ]);
+
+    function parse(obs: FredResponse) {
+      const [latest, previous] = obs.observations;
+      const value = parseFloat(latest.value);
+      const change = value - parseFloat(previous.value);
+      const trend = change > 0 ? 'up' : change < 0 ? 'down' : 'flat';
+      return { date: latest.date, value, change, trend };
+    }
+
+    const data = {
+      fedFundsRate: parse(fed),
+      cpi: parse(cpi),
+      unemployment: parse(unemp)
+    };
+
+    const insights = {
+      fedFunds: data.fedFundsRate.trend === 'up' ? 'Rates rising' :
+        data.fedFundsRate.trend === 'down' ? 'Rates falling' : 'Rates stable',
+      inflation:
+        data.cpi.trend === 'up'
+          ? 'Inflation increasing'
+          : data.cpi.trend === 'down'
+            ? 'Inflation decreasing'
+            : 'Inflation stable',
+      employment:
+        data.unemployment.trend === 'up'
+          ? 'Job market weakening'
+          : data.unemployment.trend === 'down'
+            ? 'Job market improving'
+            : 'Employment stable'
+    };
+
+    const payload = { updated: Date.now(), data, insights };
+    saveCache(payload);
+    return NextResponse.json(payload);
+  } catch (err) {
+    console.warn('Macro API failed, using cache or mock:', err);
+    const cached = loadCache();
+    if (cached) return NextResponse.json(cached);
+    const mock = {
+      updated: Date.now(),
+      data: {
+        fedFundsRate: { date: '', value: 0, change: 0, trend: 'flat' },
+        cpi: { date: '', value: 0, change: 0, trend: 'flat' },
+        unemployment: { date: '', value: 0, change: 0, trend: 'flat' }
+      },
+      insights: {
+        fedFunds: 'No data',
+        inflation: 'No data',
+        employment: 'No data'
+      }
+    };
+    return NextResponse.json(mock);
+  }
+}


### PR DESCRIPTION
## Summary
- fetch macroeconomic indicators from FRED with 24h cache
- test macro-context API success and fallback logic
- document the new `/api/macro-context` endpoint
- mark macro-context task as done in TASKS.md

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_684c7e6b844c832389f3ee63ba2edee0