### PR TITLE
Add decision support hook

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -365,7 +365,7 @@ Goal: Create a minimalist, high-performance decision support system optimized fo
   • Implement hysteresis detection to avoid oscillation during consolidation periods
   • Add API fallback hierarchy for critical signals when primary source is unavailable
 
-11.5 Create `src/hooks/useDecisionSupport.ts`
+11.5 Create `src/hooks/useDecisionSupport.ts` — DONE
   • Combine technical indicators, order book pressure, sentiment and macro context
   • Calculate aggregated decision confidence score (0-100%) for buy/sell signals
   • Include divergence detection between price action and underlying metrics

--- a/src/__tests__/decision-support.test.ts
+++ b/src/__tests__/decision-support.test.ts
@@ -1,0 +1,20 @@
+import { computeDecisionScore } from '@/hooks/useDecisionSupport';
+
+describe('computeDecisionScore', () => {
+  it('returns 50 when all factors are neutral', () => {
+    const score = computeDecisionScore({ indicator: 50, sentiment: 50, macro: 50, orderBook: 50 });
+    expect(score).toBe(50);
+  });
+
+  it('weights indicator score highest', () => {
+    const score = computeDecisionScore({ indicator: 100, sentiment: 0, macro: 0, orderBook: 0 });
+    // 100 * 0.4 = 40
+    expect(score).toBe(40);
+  });
+
+  it('combines all values with weights', () => {
+    const score = computeDecisionScore({ indicator: 80, sentiment: 60, macro: 40, orderBook: 20 });
+    const expected = Math.round(80*0.4 + 60*0.2 + 40*0.2 + 20*0.2);
+    expect(score).toBe(expected);
+  });
+});

--- a/src/hooks/useDecisionSupport.ts
+++ b/src/hooks/useDecisionSupport.ts
@@ -1,0 +1,126 @@
+import { useMemo } from 'react';
+import { useSignals } from './useSignals';
+import type { Candle, OrderBookData } from '@/lib/types';
+import { rsi14 } from '@/lib/indicators';
+import { detectDivergence } from '@/lib/indicators/oscillators';
+
+interface SocialSentiment {
+  galaxy_score?: number;
+  alt_rank?: number;
+}
+
+interface MacroContext {
+  data: {
+    fedFundsRate: { trend: string };
+    cpi: { trend: string };
+    unemployment: { trend: string };
+  };
+}
+
+export interface DecisionSupportInputs {
+  candles: Candle[];
+  sentiment?: SocialSentiment | null;
+  macro?: MacroContext | null;
+  orderBook?: OrderBookData | null;
+}
+
+export interface DecisionSupport {
+  score: number;
+  indicatorScore: number;
+  sentimentScore: number;
+  macroScore: number;
+  orderBookScore: number;
+  divergence: { bullish: boolean; bearish: boolean };
+}
+
+export function computeDecisionScore(values: {
+  indicator: number;
+  sentiment: number;
+  macro: number;
+  orderBook: number;
+}) {
+  const weights = { indicators: 0.4, sentiment: 0.2, macro: 0.2, orderBook: 0.2 };
+  const score =
+    values.indicator * weights.indicators +
+    values.sentiment * weights.sentiment +
+    values.macro * weights.macro +
+    values.orderBook * weights.orderBook;
+  return Math.max(0, Math.min(100, Math.round(score)));
+}
+
+export function useDecisionSupport({
+  candles,
+  sentiment,
+  macro,
+  orderBook,
+}: DecisionSupportInputs): DecisionSupport {
+  const { topSignal } = useSignals({ candles });
+
+  const indicatorScore = useMemo(() => {
+    return topSignal ? topSignal.confidence : 50;
+  }, [topSignal]);
+
+  const sentimentScore = useMemo(() => {
+    if (!sentiment) return 50;
+    if (typeof sentiment.galaxy_score === 'number') return sentiment.galaxy_score;
+    if (typeof sentiment.alt_rank === 'number') {
+      return 100 - Math.min(100, sentiment.alt_rank);
+    }
+    return 50;
+  }, [sentiment]);
+
+  const macroScore = useMemo(() => {
+    if (!macro) return 50;
+    let score = 50;
+    if (macro.data.fedFundsRate.trend === 'down') score += 10;
+    if (macro.data.fedFundsRate.trend === 'up') score -= 10;
+    if (macro.data.cpi.trend === 'down') score += 5;
+    if (macro.data.cpi.trend === 'up') score -= 5;
+    if (macro.data.unemployment.trend === 'down') score += 5;
+    if (macro.data.unemployment.trend === 'up') score -= 5;
+    return Math.max(0, Math.min(100, score));
+  }, [macro]);
+
+  const orderBookScore = useMemo(() => {
+    if (!orderBook) return 50;
+    const depth = 20;
+    const bidVol = orderBook.bids
+      .slice(0, depth)
+      .reduce((sum, [, qty]) => sum + parseFloat(qty), 0);
+    const askVol = orderBook.asks
+      .slice(0, depth)
+      .reduce((sum, [, qty]) => sum + parseFloat(qty), 0);
+    const total = bidVol + askVol;
+    if (!total) return 50;
+    const imbalance = (bidVol - askVol) / total;
+    return Math.round(imbalance * 50 + 50);
+  }, [orderBook]);
+
+  const score = useMemo(
+    () =>
+      computeDecisionScore({
+        indicator: indicatorScore,
+        sentiment: sentimentScore,
+        macro: macroScore,
+        orderBook: orderBookScore,
+      }),
+    [indicatorScore, sentimentScore, macroScore, orderBookScore]
+  );
+
+  const divergence = useMemo(() => {
+    const rsiSeries: number[] = [];
+    for (let i = 0; i < candles.length; i++) {
+      rsiSeries.push(rsi14(candles.slice(0, i + 1)));
+    }
+    return detectDivergence(candles, rsiSeries);
+  }, [candles]);
+
+  return {
+    score,
+    indicatorScore,
+    sentimentScore,
+    macroScore,
+    orderBookScore,
+    divergence,
+  };
+}


### PR DESCRIPTION
## Summary
- implement `useDecisionSupport` hook
- expose `computeDecisionScore` helper
- test score calculation
- mark Decision Support task as done

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_684c7faf468c8323a9fd96849c495f4f