### PR TITLE
Add on-chain insights panel

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -426,7 +426,7 @@ Goal: Create a minimalist, high-performance decision support system optimized fo
   • Add 1-hour caching with revalidation for these less frequently changing metrics
   • Implement lightweight data normalization to reduce payload size
 
-13.2 Create `src/components/OnChainInsightsPanel.tsx`
+13.2 Create `src/components/OnChainInsightsPanel.tsx` — DONE
   • Build a compact UI component showing key on-chain metrics
   • Add visual indicators for unusual network activity
   • Include togglable detail view for in-depth analysis

--- a/src/components/LiveDashboard.tsx
+++ b/src/components/LiveDashboard.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { Candle, OrderBookData, Trade } from '@/lib/types';
 import SignalsDisplay from './SignalsDisplay';
+import OnChainInsightsPanel from './OnChainInsightsPanel';
 import { useSignals } from '@/hooks/useSignals';
 import { browserCache, withCache } from '@/lib/cache/browserCache';
 import DataFreshnessIndicator from './DataFreshnessIndicator';
@@ -199,6 +200,9 @@ export default function LiveDashboard({ refreshTrigger = 0 }: LiveDashboardProps
           className="hover:bg-white/5 px-2 py-1 rounded-md cursor-pointer transition-colors"
         />
       </div>
+
+      {/* On-Chain Insights */}
+      <OnChainInsightsPanel />
       
       {/* Price Overview and Signals */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/src/components/OnChainInsightsPanel.tsx
+++ b/src/components/OnChainInsightsPanel.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { DataCard } from './DataCard';
+
+interface OnChainData {
+  tx_count: number;
+  mempool_transactions: number;
+  total_fees_btc: number;
+  timestamp: number;
+}
+
+export default function OnChainInsightsPanel() {
+  const [data, setData] = useState<OnChainData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch('/api/btc-onchain');
+        if (!res.ok) throw new Error(`status ${res.status}`);
+        const json = await res.json();
+        setData(json);
+      } catch (err) {
+        console.error('Failed to load on-chain data:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const isAlert = (value: number, threshold: number) => value > threshold;
+
+  const toggleExpanded = () => setExpanded(prev => !prev);
+
+  return (
+    <DataCard>
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-xl font-medium">On-Chain Metrics</h2>
+        <button
+          onClick={toggleExpanded}
+          className="text-xs hover:underline"
+        >
+          {expanded ? 'Hide' : 'Details'}
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="animate-pulse">Loading...</div>
+      ) : data ? (
+        <>
+          <div className="space-y-1 text-sm">
+            <div className={`flex justify-between ${isAlert(data.tx_count, 350000) ? 'text-yellow-300' : ''}`}> 
+              <span>Transactions</span>
+              <span>{data.tx_count.toLocaleString()}</span>
+            </div>
+            <div className={`flex justify-between ${isAlert(data.mempool_transactions, 100000) ? 'text-yellow-300' : ''}`}> 
+              <span>Mempool</span>
+              <span>{data.mempool_transactions.toLocaleString()}</span>
+            </div>
+            <div className={`flex justify-between ${isAlert(data.total_fees_btc, 100) ? 'text-yellow-300' : ''}`}> 
+              <span>Total Fees (BTC)</span>
+              <span>{data.total_fees_btc.toFixed(2)}</span>
+            </div>
+          </div>
+          {expanded && (
+            <div className="mt-2 text-xs text-white/70">
+              Last updated: {new Date(data.timestamp).toLocaleString()}
+            </div>
+          )}
+        </>
+      ) : (
+        <div>No data available</div>
+      )}
+    </DataCard>
+  );
+}


### PR DESCRIPTION
## Summary
- build `OnChainInsightsPanel` to show `/api/btc-onchain` data with alerting and collapsible details
- hook panel into `LiveDashboard`
- mark task 13.2 complete

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c80948394832381eb02686afca76a