### PR TITLE
Add signal performance tracker tests

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -387,7 +387,7 @@ Mark each task as complete only when ALL criteria are met:
 - [x] **Task 5:** Price Target Calculator (Completed: ATR-based stop loss with 2:1 risk-reward)
 - [x] **Task 6:** Market Regime Detection (Completed: Regime classification with confidence scoring)
 - [x] **Task 7:** Real-Time Alert System (Completed: Browser notifications with sound alerts)
-- [x] **Task 8:** Performance Tracking (Completed: Win rate, P&L, and trade metrics)
+- [x] **Task 8:** Performance Tracking (Completed: Win rate, P&L, and trade metrics) - Jest tests added
 - [ ] **Task 9:** Quick Action Panel
 - [ ] **Task 10:** Data Freshness & Reliability
 

--- a/src/__tests__/signal-performance.test.ts
+++ b/src/__tests__/signal-performance.test.ts
@@ -1,0 +1,48 @@
+import { SignalPerformanceTracker } from '@/lib/tracking/signal-performance';
+
+describe('SignalPerformanceTracker', () => {
+  it('records trades and calculates metrics', () => {
+    const tracker = new SignalPerformanceTracker();
+
+    tracker.recordEntry({
+      id: 't1',
+      entrySignalId: 's1',
+      entryPrice: 100,
+      entryTime: 0,
+      positionSize: 1,
+    });
+    tracker.recordEntry({
+      id: 't2',
+      entrySignalId: 's2',
+      entryPrice: 100,
+      entryTime: 1,
+      positionSize: 1,
+    });
+    tracker.recordEntry({
+      id: 't3',
+      entrySignalId: 's3',
+      entryPrice: 100,
+      entryTime: 2,
+      positionSize: 1,
+    });
+
+    expect(tracker.getOpenTrades()).toHaveLength(3);
+    expect(tracker.getClosedTrades()).toHaveLength(0);
+
+    tracker.recordExit('t1', 110, 10);
+    expect(tracker.getOpenTrades()).toHaveLength(2);
+    expect(tracker.getClosedTrades()).toHaveLength(1);
+
+    tracker.recordExit('t2', 90, 20);
+    tracker.recordExit('t3', 105, 30);
+
+    expect(tracker.getOpenTrades()).toHaveLength(0);
+    expect(tracker.getClosedTrades()).toHaveLength(3);
+
+    const metrics = tracker.calculateMetrics();
+    expect(metrics.totalTrades).toBe(3);
+    expect(metrics.winRate).toBeCloseTo(66.67, 1);
+    expect(metrics.profitFactor).toBeCloseTo(1.5, 2);
+    expect(metrics.maxDrawdown).toBeCloseTo(10, 1);
+  });
+});


### PR DESCRIPTION
## Summary
- add jest tests for `SignalPerformanceTracker`
- note in TASKS that performance tracking now has tests

## Testing
- `npm test` *(fails: 1 failed, 6 passed)*

------
https://chatgpt.com/codex/tasks/task_b_684df289bef88323bef3e0954636c49e