### PR TITLE
Add EMA crossover unit tests

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -390,6 +390,7 @@ Mark each task as complete only when ALL criteria are met:
 - [x] **Task 8:** Performance Tracking (Completed: Win rate, P&L, and trade metrics)
 - [ ] **Task 9:** Quick Action Panel
 - [ ] **Task 10:** Data Freshness & Reliability
+- [x] **Test:** EMA crossover logic unit tests added
 
 **Final Success Criteria:**
 - ✅ Dashboard helps users identify 2-3 daily Bitcoin trading opportunities

--- a/src/__tests__/ema-crossover.test.ts
+++ b/src/__tests__/ema-crossover.test.ts
@@ -1,0 +1,55 @@
+import { detectEMACross } from '@/lib/signals/ema-crossover';
+import type { Candle } from '@/lib/types';
+
+function genCandles(prices: number[]): Candle[] {
+  return prices.map((p, i) => ({
+    time: i,
+    open: p,
+    high: p,
+    low: p,
+    close: p,
+    volume: 100,
+  }));
+}
+
+describe('detectEMACross', () => {
+  it('returns BUY on bullish crossover', () => {
+    const prices = [...Array(21).fill(100), 90, 80, 120];
+    const candles = genCandles(prices);
+    const res = detectEMACross(candles);
+    expect(res.signal.type).toBe('BUY');
+  });
+
+  it('returns SELL on bearish crossover', () => {
+    const prices = [...Array(21).fill(100), 120, 120, 80, 70];
+    const candles = genCandles(prices);
+    const res = detectEMACross(candles);
+    expect(res.signal.type).toBe('SELL');
+  });
+
+  it('returns NEUTRAL when no crossover', () => {
+    const candles = genCandles(new Array(25).fill(100));
+    const res = detectEMACross(candles);
+    expect(res.signal.type).toBe('NEUTRAL');
+  });
+
+  it('RSI lowers confidence when overbought on bullish cross', () => {
+    const neutralPrices = [...Array(21).fill(100), 90, 80, 120];
+    const overboughtPrices = [...Array(21).fill(100), 80, 80, 120, 130];
+    const neutral = detectEMACross(genCandles(neutralPrices));
+    const overbought = detectEMACross(genCandles(overboughtPrices));
+    expect(neutral.signal.type).toBe('BUY');
+    expect(overbought.signal.type).toBe('BUY');
+    expect(neutral.signal.confidence).toBeGreaterThan(overbought.signal.confidence);
+  });
+
+  it('RSI lowers confidence when oversold on bearish cross', () => {
+    const neutralPrices = [...Array(21).fill(100), 110, 90, 94];
+    const oversoldPrices = [...Array(21).fill(100), 120, 120, 80, 70];
+    const neutral = detectEMACross(genCandles(neutralPrices));
+    const oversold = detectEMACross(genCandles(oversoldPrices));
+    expect(neutral.signal.type).toBe('SELL');
+    expect(oversold.signal.type).toBe('SELL');
+    expect(neutral.signal.confidence).toBeGreaterThan(oversold.signal.confidence);
+  });
+});

--- a/src/lib/market/regime.ts
+++ b/src/lib/market/regime.ts
@@ -282,30 +282,32 @@ export class MarketRegimeDetector {
     const minusDIAvg = this.minusDMs.reduce((sum, val) => sum + val, 0) / this.adxPeriod;
 }
 
+/*
 // Calculate all indicators
 this.calculateADX();
 this.calculateRSI();
 this.calculateEMA();
- 
+
 // Determine the current market regime
 this.determineRegime();
 
 // Add to history if regime changed
-if (this.regimeHistory.length === 0 || 
+if (this.regimeHistory.length === 0 ||
     this.regimeHistory[this.regimeHistory.length - 1].regime !== this.currentRegime) {
   this.regimeStartTime = Date.now();
   this.regimeHistory.push({
     timestamp: Date.now(),
     regime: this.currentRegime
   });
-  
+
   // Keep history size in check
   if (this.regimeHistory.length > this.maxHistory) {
     this.regimeHistory.shift();
   }
 }
- 
+
 return this.getCurrentAnalysis();
+*/
 }
 
  


### PR DESCRIPTION
## Summary
- add unit tests for EMA cross detection
- document task completion
- stub out unused portion of MarketRegimeDetector to fix build

## Testing
- `npm test` *(fails: 8 failed, 20 passed)*

------
https://chatgpt.com/codex/tasks/task_b_684df286d27883238bb33d8e1cdeaad2