### PR TITLE
Enhance QuickActionPanel

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -389,7 +389,7 @@ Mark each task as complete only when ALL criteria are met:
 - [x] **Task 7:** Real-Time Alert System (Completed: Browser notifications with sound alerts)
 - [x] **Task 8:** Performance Tracking (Completed: Win rate, P&L, and trade metrics)
 - [x] MarketRegimeDetector unit tests implemented
-- [x] **Task 9:** Quick Action Panel
+- [x] **Task 9:** Quick Action Panel (Completed: Buy/Sell, alerts, position sizing, export)
 - [x] **Task 10:** Data Freshness & Reliability
 
 **Final Success Criteria:**

--- a/src/components/QuickActionPanel.tsx
+++ b/src/components/QuickActionPanel.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useMemo } from 'react';
 import { calculatePositionSize } from '@/lib/calculators/price-targets';
+import { performanceTracker } from '@/lib/tracking/signal-performance';
+import { loadTrades, saveTrades } from '@/lib/storage/trade-history';
 import { cn } from '@/lib/utils';
 import { DataCard } from './DataCard';
 
@@ -18,6 +20,7 @@ export default function QuickActionPanel({ latestPrice = 0, className = '' }: Qu
   const [riskPct, setRiskPct] = useState<number>(1);
   const [feesPct, setFeesPct] = useState<number>(0.1);
   const [alertPrice, setAlertPrice] = useState<number>(latestPrice || 0);
+  const [openTradeId, setOpenTradeId] = useState<string | null>(null);
 
   useEffect(() => {
     if (latestPrice) {
@@ -41,17 +44,63 @@ export default function QuickActionPanel({ latestPrice = 0, className = '' }: Qu
   }, [entry, stop, target]);
 
   const breakEven = useMemo(() => entry * (1 + (feesPct / 100) * 2), [entry, feesPct]);
+  const profitAtTarget = useMemo(() => (target - entry) * positionSize, [target, entry, positionSize]);
+  const lossAtStop = useMemo(() => (entry - stop) * positionSize, [entry, stop, positionSize]);
 
   const executeBuy = () => {
-    console.log('Execute BUY', { entry, positionSize });
+    const id = `trade-${Date.now()}`;
+    performanceTracker.recordEntry({
+      id,
+      entrySignalId: 'manual-buy',
+      entryPrice: entry,
+      entryTime: Date.now(),
+      positionSize,
+      metadata: { entryReason: 'Quick Action BUY' },
+    });
+    const trades = loadTrades();
+    trades.push({
+      id,
+      entrySignalId: 'manual-buy',
+      entryPrice: entry,
+      entryTime: Date.now(),
+      positionSize,
+      status: 'open',
+    });
+    saveTrades(trades);
+    setOpenTradeId(id);
   };
 
   const executeSell = () => {
-    console.log('Execute SELL', { entry, positionSize });
+    if (!openTradeId) return;
+    performanceTracker.recordExit(openTradeId, entry, Date.now(), 'Quick Action SELL');
+    const trades = loadTrades().map(t => {
+      if (t.id === openTradeId && t.status === 'open') {
+        const pnlPercent = ((entry - t.entryPrice) / t.entryPrice) * 100;
+        const pnlAbsolute = (entry - t.entryPrice) * t.positionSize;
+        return { ...t, exitPrice: entry, exitTime: Date.now(), pnlPercent, pnlAbsolute, status: 'closed' };
+      }
+      return t;
+    });
+    saveTrades(trades);
+    setOpenTradeId(null);
   };
 
   const setPriceAlert = () => {
-    alert(`Price alert set at ${alertPrice}`);
+    if (typeof window === 'undefined') return;
+    try {
+      localStorage.setItem('bd_price_alert', alertPrice.toString());
+      if ('Notification' in window) {
+        Notification.requestPermission().then(p => {
+          if (p === 'granted') {
+            new Notification('Price Alert Set', { body: `Alert at ${alertPrice}` });
+          }
+        });
+      } else {
+        alert(`Price alert set at ${alertPrice}`);
+      }
+    } catch {
+      alert(`Price alert set at ${alertPrice}`);
+    }
   };
 
   const exportData = () => {
@@ -75,6 +124,29 @@ export default function QuickActionPanel({ latestPrice = 0, className = '' }: Qu
     link.click();
     link.remove();
     URL.revokeObjectURL(url);
+  };
+
+  const copyToClipboard = async () => {
+    const text = `Entry:${entry}, Stop:${stop}, Target:${target}, Size:${positionSize}`;
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      console.warn('Copy failed');
+    }
+  };
+
+  const savePlan = () => {
+    try {
+      localStorage.setItem('bd_trade_plan', JSON.stringify({ entry, stop, target, account, riskPct }));
+    } catch (e) {
+      console.error('Failed to save plan', e);
+    }
+  };
+
+  const sharePlan = () => {
+    if (navigator.share) {
+      navigator.share({ title: 'Trade Plan', text: `Entry ${entry} Stop ${stop} Target ${target}` });
+    }
   };
 
   const inputClass = 'bg-neutral-800 rounded px-2 py-1 text-sm';
@@ -101,7 +173,15 @@ export default function QuickActionPanel({ latestPrice = 0, className = '' }: Qu
         </label>
         <label className="flex flex-col">
           <span>Risk %</span>
-          <input type="number" className={inputClass} value={riskPct} onChange={e => setRiskPct(parseFloat(e.target.value))} />
+          <input
+            type="range"
+            min="0.5"
+            max="5"
+            step="0.1"
+            value={riskPct}
+            onChange={e => setRiskPct(parseFloat(e.target.value))}
+          />
+          <span className="text-center mt-1">{riskPct.toFixed(1)}%</span>
         </label>
         <label className="flex flex-col">
           <span>Fees %</span>
@@ -116,12 +196,18 @@ export default function QuickActionPanel({ latestPrice = 0, className = '' }: Qu
         <div>Position Size: <span className="font-mono">{positionSize.toFixed(4)}</span></div>
         <div>Risk/Reward: <span className="font-mono">{riskReward.toFixed(2)}</span></div>
         <div>Break-Even: <span className="font-mono">{breakEven.toFixed(2)}</span></div>
+        <div>Profit @ Target: <span className="font-mono">{profitAtTarget.toFixed(2)}</span></div>
+        <div>Loss @ Stop: <span className="font-mono">{lossAtStop.toFixed(2)}</span></div>
       </div>
       <div className="grid grid-cols-2 gap-2 text-sm">
         <button onClick={executeBuy} className="bg-green-600 hover:bg-green-700 rounded px-2 py-1">BUY</button>
         <button onClick={executeSell} className="bg-red-600 hover:bg-red-700 rounded px-2 py-1">SELL</button>
         <button onClick={setPriceAlert} className="col-span-2 bg-yellow-600 hover:bg-yellow-700 rounded px-2 py-1">Set Price Alert</button>
         <button onClick={exportData} className="col-span-2 bg-blue-600 hover:bg-blue-700 rounded px-2 py-1">Export Data</button>
+        <button onClick={copyToClipboard} className="col-span-2 bg-neutral-600 hover:bg-neutral-700 rounded px-2 py-1">Copy</button>
+        <button onClick={savePlan} className="col-span-2 bg-neutral-600 hover:bg-neutral-700 rounded px-2 py-1">Save Plan</button>
+        <a href="https://www.binance.com/en/trade/BTC_USDT" target="_blank" rel="noopener" className="col-span-2 bg-neutral-700 hover:bg-neutral-800 rounded px-2 py-1 text-center">Open Exchange</a>
+        <button onClick={sharePlan} className="col-span-2 bg-neutral-500 hover:bg-neutral-600 rounded px-2 py-1">Share</button>
       </div>
     </DataCard>
   );


### PR DESCRIPTION
## Summary
- extend QuickActionPanel with trade logging, profit/loss estimates
- add buttons for copy, save, open exchange and share
- update Task 9 description in TASKS.md

## Testing
- `npm run lint` *(fails: next not found and many lint errors)*
- `npm test` *(fails: several tests failing)*

------
https://chatgpt.com/codex/tasks/task_b_684df8c8929c83238b0d72ae6579ef3b