### PR TITLE
Fix tasks doc and add testing results

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -160,7 +160,7 @@ Complete tasks in order. Each task builds on the previous one. Test after every 
 
 ---
 
-### ✅ **TASK 6: Market Regime Detection** (COMPLETED)
+### ✅ **TASK 6: Market Regime Detection**
 **Implementation Details:**
 - Created advanced `MarketRegimeDetector` class with multiple indicators
 - Implemented 5 distinct market regimes: Strong/Weak Up/Down trends and Ranging
@@ -182,7 +182,7 @@ Complete tasks in order. Each task builds on the previous one. Test after every 
 
 ---
 
-### ✅ **TASK 7: Real-Time Alert System** (COMPLETED)
+### ✅ **TASK 7: Real-Time Alert System**
 **Implementation Details:**
 - Created a comprehensive alert system with browser notifications and sound alerts
 - Built a responsive `AlertManager` component with a clean, modern UI
@@ -200,53 +200,6 @@ Complete tasks in order. Each task builds on the previous one. Test after every 
 
 ---
 
-### **TASK 8: Performance Tracking** (60 min)
-**Goal:** Track and display the performance of trading signals
-
-**Files to create/edit:**
-- `src/lib/tracking/signal-performance.ts` (create)
-- `src/components/PerformanceMetrics.tsx` (create)
-- `src/lib/storage/trade-history.ts` (create)
-
-**What to build:**
-1. **Signal Performance Tracking:**
-   - Record entry/exit prices for each signal
-   - Calculate win/loss statistics
-   - Track profit/loss in percentage and absolute terms
-   
-2. **Performance Metrics:**
-   - Win rate percentage
-   - Average win/loss ratio
-   - Total profit/loss
-   - Maximum drawdown
-   - Risk-adjusted returns
-
-3. **Visual Dashboard:**
-   - Clean, at-a-glance metrics display
-   - Performance charts over time
-   - Trade history with filtering options
-   - Export functionality for analysis
-
-**Testing:**
-- Verify accurate calculation of all metrics
-- Test with mock trade data
-- Ensure performance updates in real-time
-
-**Success Criteria:**
-✅ Accurate performance metrics displayed  
-✅ Real-time updates as signals trigger  
-✅ Clean, intuitive visualization of results  
-✅ Persistent storage of trade history
-
-**Next Steps:**
-1. Add more alert types and customization options
-2. Implement push notifications for web/mobile
-3. Add alert history and filtering
-4. Create a demo page to test the alert system
-
-**Demo Available:** `/alerts-demo`
-
----
 
 ### **TASK 8: Performance Tracking** (90 min)
 **Goal:** Track signal accuracy and help users improve their trading
@@ -282,6 +235,11 @@ Complete tasks in order. Each task builds on the previous one. Test after every 
 ---
 
 ### **TASK 9: Quick Action Panel** (45 min)
+**Implementation Details:**
+- Built `QuickActions` component with Radix UI
+- Added helpers in `quick-trades.ts` for trade execution
+- Integrated panel into `LiveDashboard`
+
 **Goal:** Provide one-click access to common trading actions
 
 **Files to create/edit:**
@@ -315,6 +273,11 @@ Complete tasks in order. Each task builds on the previous one. Test after every 
 ---
 
 ### **TASK 10: Data Freshness & Reliability** (60 min)
+**Implementation Details:**
+- Enhanced `DataFreshnessIndicator` with color-coded status
+- Added `data-health.ts` to monitor API latency and errors
+- Updated `smart-cache.ts` for auto-refresh and fallback
+
 **Goal:** Ensure users always know how current their data is
 
 **Files to create/edit:**
@@ -405,3 +368,6 @@ Mark each task as complete only when ALL criteria are met:
 
 **Ready for Production:** When all 10 tasks complete with full testing validation
 - ✅ Unused development files removed (LiveDashboard.tsx.new, LiveDashboard.fixed.tsx, dashboard/page.new.tsx)
+
+## Testing Results
+All Jest tests executed. 2 test suites failed: market-regime and indicators.


### PR DESCRIPTION
## Summary
- remove duplicate Performance Tracking task description
- standardize completed task headers
- add implementation details for the last two tasks
- document failing test results

## Testing
- `npm test` *(fails: market-regime.test.ts, indicators.test.ts)*

------
https://chatgpt.com/codex/tasks/task_b_684dfda6841883239de6bd68e034cd25