### PR TITLE
Implement agents and UI pieces

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,6 +3,8 @@ import { CandleChart } from '@/components/CandleChart';
 import { MarketRegimeIndicator } from '@/components/MarketRegimeIndicator';
 import PerformanceMetricsPanel from '@/components/dashboard/PerformanceMetricsPanel';
 import BasicCandleDisplay from '@/components/BasicCandleDisplay';
+import DataFreshnessIndicator from '@/components/DataFreshnessIndicator';
+import SignalDisplay from '@/components/SignalDisplay';
 import dynamic from 'next/dynamic';
 
 // Dynamically import PerformanceMetrics with no SSR since it uses browser APIs
@@ -95,7 +97,10 @@ export default function DashboardPage() {
           <div className="bg-white p-4 rounded-lg shadow-sm border">
             <CandleChart height={600} />
           </div>
-          
+
+          <DataFreshnessIndicator />
+          <SignalDisplay />
+
           {/* Basic Candle Display */}
           <div className="bg-white p-4 rounded-lg shadow-sm border">
             <h2 className="text-lg font-medium mb-3">Basic Candle Display</h2>

--- a/src/components/DataFreshnessIndicator.tsx
+++ b/src/components/DataFreshnessIndicator.tsx
@@ -1,155 +1,55 @@
-'use client';
+"use client";
+import React, { useState, useEffect } from 'react';
+import { useAppState } from '@/hooks/useAppState';
 
-import { useEffect, useState } from 'react';
-import { BrowserCache } from '@/lib/cache/browserCache';
-
-interface DataFreshnessIndicatorProps {
-  lastUpdated: number | null;
-  dataSource?: string;
-  cacheKey?: string;
-  browserCache?: BrowserCache;
-  className?: string;
-  connectionStatus?: 'connecting' | 'connected' | 'disconnected' | 'error';
-  onRefresh?: () => void;
-  refreshInterval?: number;
-}
-
-/**
- * Component that displays the freshness status of data and its source
- */
-export default function DataFreshnessIndicator({
-  lastUpdated,
-  dataSource = 'unknown',
-  cacheKey,
-  browserCache,
-  className = '',
-  connectionStatus,
-  onRefresh,
-  refreshInterval = 30000
-}: DataFreshnessIndicatorProps) {
-  const [age, setAge] = useState<number>(0);
-  const [status, setStatus] = useState<'fresh' | 'warn' | 'stale' | 'unknown'>('unknown');
-  const [timeSinceUpdate, setTimeSinceUpdate] = useState<string>('');
-  const [isExpanded, setIsExpanded] = useState(false);
+export default function DataFreshnessIndicator() {
+  const { dataStatus, dataError } = useAppState();
+  const [statusText, setStatusText] = useState(dataStatus.text);
+  const [statusColor, setStatusColor] = useState(dataStatus.color);
 
   useEffect(() => {
-    if (lastUpdated) {
-      updateFreshness(lastUpdated);
-      const interval = setInterval(() => {
-        updateFreshness(lastUpdated);
-        if (onRefresh && Date.now() - lastUpdated > refreshInterval) {
-          onRefresh();
-        }
-      }, 10000);
+    if (dataError) {
+      setStatusText(`Error: ${dataError.substring(0,30)}`);
+      setStatusColor('red');
+      return;
+    }
 
-      return () => clearInterval(interval);
-    }
-  }, [lastUpdated, onRefresh, refreshInterval]);
-  
-  // Check cache details if browser cache instance and key are provided
-  useEffect(() => {
-    if (browserCache && cacheKey) {
-      const checkCache = async () => {
-        const freshness = await browserCache.getFreshness(cacheKey);
-        
-        // Update attributes with the cache info
-        if (freshness > 0) {
-          setAge(freshness);
-          updateStatusByAge(freshness);
-        }
-      };
-      
-      checkCache();
-    }
-  }, [browserCache, cacheKey]);
-  
-  const updateFreshness = (timestamp: number) => {
-    const now = Date.now();
-    const ageMs = now - timestamp;
-    setAge(ageMs);
-    updateStatusByAge(ageMs);
-    setTimeSinceUpdate(formatTimeSince(ageMs));
-  };
-  
-  const updateStatusByAge = (ageMs: number) => {
-    if (ageMs < 30000) {
-      setStatus('fresh');
-    } else if (ageMs < 120000) {
-      setStatus('warn');
-    } else {
-      setStatus('stale');
-    }
-  };
-  
-  const formatTimeSince = (ms: number): string => {
-    const seconds = Math.floor(ms / 1000);
-    if (seconds < 60) return `${seconds}s ago`;
-    
-    const minutes = Math.floor(seconds / 60);
-    if (minutes < 60) return `${minutes}m ago`;
-    
-    const hours = Math.floor(minutes / 60);
-    if (hours < 24) return `${hours}h ago`;
-    
-    const days = Math.floor(hours / 24);
-    return `${days}d ago`;
-  };
-  
-  const getStatusColor = () => {
-    if (dataSource === 'mock' || dataSource === 'cached') {
-      return 'bg-gray-500';
-    }
-    switch (status) {
-      case 'fresh':
-        return 'bg-green-500';
-      case 'warn':
-        return 'bg-yellow-500';
-      case 'stale':
-        return 'bg-red-500';
-      default:
-        return 'bg-gray-500';
-    }
-  };
-  
-  const getSourceBadge = () => {
-    switch (dataSource) {
-      case 'binance':
-        return 'bg-yellow-800 text-yellow-200';
-      case 'coingecko':
-        return 'bg-blue-800 text-blue-200';
-      case 'mock':
-        return 'bg-red-800 text-red-200';
-      case 'cached':
-        return 'bg-gray-700 text-gray-300';
-      default:
-        return 'bg-gray-700 text-gray-300';
-    }
-  };
-  
-  const toggleExpanded = () => setIsExpanded(!isExpanded);
+    const lastUpdateTime = dataStatus.lastUpdateTime;
+
+    const intervalId = setInterval(() => {
+      if (statusColor === 'red') return;
+      if (lastUpdateTime === null) {
+        setStatusText(dataStatus.text);
+        setStatusColor(dataStatus.color);
+        return;
+      }
+
+      const ageSeconds = (Date.now() - lastUpdateTime) / 1000;
+
+      if (ageSeconds < 10) {
+        setStatusText("● Live");
+        setStatusColor("green");
+      } else if (ageSeconds < 30) {
+        setStatusText(`● ${Math.round(ageSeconds)}s ago`);
+        setStatusColor("lightgreen");
+      } else if (ageSeconds < 120) {
+        setStatusText(`● ${Math.round(ageSeconds)}s ago (stale)`);
+        setStatusColor("orange");
+      } else {
+        setStatusText(`● >2m stale!`);
+        setStatusColor("red");
+      }
+    }, 2000);
+
+    return () => {
+      console.log('DataFreshnessIndicator: Unmounting.');
+      clearInterval(intervalId);
+    };
+  }, [dataStatus, dataError, statusColor]);
 
   return (
-    <div
-      className={`flex flex-col text-xs ${className}`}
-      onClick={toggleExpanded}
-    >
-      <div className="flex items-center cursor-pointer gap-1">
-        <div className={`w-2 h-2 rounded-full ${getStatusColor()}`}></div>
-        {connectionStatus && (
-          <div className={`w-2 h-2 rounded-full ${connectionStatus === 'connected' ? 'bg-green-500' : connectionStatus === 'connecting' ? 'bg-yellow-500' : connectionStatus === 'error' ? 'bg-red-500' : 'bg-gray-500'}`}></div>
-        )}
-        <span>{timeSinceUpdate || 'Unknown'}</span>
-        <span className={`px-1 py-0.5 text-2xs rounded ${getSourceBadge()}`}>{dataSource}</span>
-      </div>
-      
-      {isExpanded && (
-        <div className="mt-1 ml-4 text-2xs text-gray-400">
-          <div>Last update: {lastUpdated ? new Date(lastUpdated).toLocaleString() : 'Unknown'}</div>
-          <div>Status: {status}</div>
-          <div>Age: {formatTimeSince(age)}</div>
-          {connectionStatus && <div>Connection: {connectionStatus}</div>}
-        </div>
-      )}
+    <div style={{ padding: '5px', border: '1px solid #ddd', borderRadius: '4px', backgroundColor: '#f9f9f9' }}>
+      Data Status: <strong style={{ color: statusColor }}>{statusText}</strong>
     </div>
   );
 }

--- a/src/components/SignalDisplay.tsx
+++ b/src/components/SignalDisplay.tsx
@@ -1,0 +1,48 @@
+// src/components/SignalDisplay.tsx
+"use client";
+import React from 'react';
+import { useAppState } from '@/hooks/useAppState';
+
+export default function SignalDisplay() {
+  const { latestSignal } = useAppState();
+
+  if (!latestSignal) {
+    return <div className="p-4 text-center text-gray-500">Awaiting first signal...</div>;
+  }
+
+  const { action, confidence, reason, marketRegime, entryPrice, stopLoss, takeProfit, timestamp, rawIndicators } = latestSignal;
+
+  const getActionColor = () => {
+    if (action === 'BUY') return 'green';
+    if (action === 'SELL') return 'red';
+    return 'gray';
+  };
+
+  return (
+    <div style={{ border: `3px solid ${getActionColor()}`, padding: '15px', margin: '10px 0', borderRadius: '8px', backgroundColor: '#fff' }}>
+      <h3 style={{ color: getActionColor(), marginTop: 0, marginBottom: '10px', fontSize: '1.5em' }}>
+        Current Signal: {action}
+      </h3>
+      <p><strong>Confidence: {confidence.toFixed(1)}%</strong></p>
+      <p><strong>Reason:</strong> {reason}</p>
+      <p><strong>Market Regime:</strong> {marketRegime}</p>
+      <p><strong>Signal Time:</strong> {new Date(timestamp).toLocaleTimeString()}</p>
+      {action !== 'HOLD' && entryPrice && (
+        <>
+          <hr style={{margin: '10px 0'}} />
+          <p><strong>Entry Price:</strong> {entryPrice.toFixed(2)}</p>
+          <p><strong>Stop-Loss:</strong> {stopLoss?.toFixed(2) || 'N/A (Check ATR)'}</p>
+          <p><strong>Take-Profit:</strong> {takeProfit?.toFixed(2) || 'N/A (Check ATR)'}</p>
+        </>
+      )}
+      {rawIndicators && (
+        <details style={{marginTop: '10px'}}>
+          <summary style={{cursor: 'pointer', fontWeight: 'bold'}}>Raw Indicators (at signal time)</summary>
+          <pre style={{ fontSize: '0.8em', backgroundColor: '#f0f0f0', padding: '10px', borderRadius: '4px', maxHeight: '150px', overflowY: 'auto' }}>
+            {JSON.stringify(rawIndicators, null, 2)}
+          </pre>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useAppState.ts
+++ b/src/hooks/useAppState.ts
@@ -1,0 +1,15 @@
+// src/hooks/useAppState.ts
+import { useState, useEffect } from 'react';
+import { uiAdapter } from '@/lib/agents/UIAdapter';
+import { AppState } from '@/lib/agents/types';
+
+export function useAppState() {
+  const [appState, setAppState] = useState<AppState>(() => uiAdapter.getState());
+
+  useEffect(() => {
+    const unsub = uiAdapter.subscribe(setAppState);
+    return unsub;
+  }, []);
+
+  return appState;
+}

--- a/src/lib/agents/DataCollector.ts
+++ b/src/lib/agents/DataCollector.ts
@@ -227,6 +227,13 @@ export class DataCollectorAgent {
           payload: { ...candle, isClosed },
           timestamp: Date.now()
         });
+
+        orchestrator.send<{ lastUpdateTime: number; lastCandleTime: number }>({
+          from: 'DataCollector',
+          type: 'DATA_STATUS_UPDATE',
+          payload: { lastUpdateTime: Date.now(), lastCandleTime: candle.time },
+          timestamp: Date.now()
+        });
         
       } catch (error) {
         console.error('DataCollector: Error processing candle update:', error);

--- a/src/lib/agents/IndicatorEngine.ts
+++ b/src/lib/agents/IndicatorEngine.ts
@@ -1,0 +1,90 @@
+// src/lib/agents/IndicatorEngine.ts
+import { orchestrator } from './Orchestrator';
+import { AgentMessage, AgentName, MessageHandler, IndicatorDataSet } from './types';
+import { Candle } from '@/lib/types';
+
+import { candleEMA } from '@/lib/indicators/moving-averages';
+import { calculateRSI } from '@/lib/indicators/rsi';
+import { bollingerBands } from '@/lib/indicators/volatility';
+import { calculateATR } from '@/lib/indicators/atr';
+
+const EMA_FAST_PERIOD = 9;
+const EMA_SLOW_PERIOD = 21;
+const RSI_PERIOD = 14;
+const BB_PERIOD = 20;
+const BB_STDDEV = 2;
+const ATR_PERIOD = 14;
+
+const MIN_CANDLES_FOR_INDICATORS = Math.max(EMA_SLOW_PERIOD, RSI_PERIOD, BB_PERIOD, ATR_PERIOD) + 5;
+const MAX_CANDLE_HISTORY = 200;
+
+class IndicatorEngineAgent {
+  private candles: Candle[] = [];
+
+  constructor() {
+    console.log('IndicatorEngineAgent: Constructor called. Subscribing to NEW_CLOSED_CANDLE_5M.');
+    orchestrator.register('NEW_CLOSED_CANDLE_5M', this.onNewClosedCandle.bind(this) as MessageHandler);
+    orchestrator.register('INITIAL_CANDLES_5M', this.handleInitialCandles.bind(this) as MessageHandler);
+  }
+
+  private handleInitialCandles(msg: AgentMessage<Candle[]>): void {
+    console.log('IndicatorEngineAgent: Received initial candles. Storing for calculations.');
+    this.candles = [...msg.payload].sort((a,b) => a.time - b.time);
+    if (this.candles.length > MAX_CANDLE_HISTORY) {
+      this.candles = this.candles.slice(-MAX_CANDLE_HISTORY);
+    }
+    if (this.candles.length >= MIN_CANDLES_FOR_INDICATORS) {
+      const latestCandle = this.candles[this.candles.length -1];
+      this.calculateAndSendIndicators(latestCandle);
+    }
+  }
+
+  private onNewClosedCandle(msg: AgentMessage<Candle>): void {
+    const newCandle = msg.payload;
+    const existingIndex = this.candles.findIndex(c => c.time === newCandle.time);
+    if (existingIndex === -1) {
+      this.candles.push(newCandle);
+      this.candles.sort((a,b) => a.time - b.time);
+      if (this.candles.length > MAX_CANDLE_HISTORY) {
+        this.candles.shift();
+      }
+    } else {
+      this.candles[existingIndex] = newCandle;
+    }
+    this.calculateAndSendIndicators(newCandle);
+  }
+
+  private calculateAndSendIndicators(triggeringCandle: Candle): void {
+    if (this.candles.length < MIN_CANDLES_FOR_INDICATORS) {
+      return;
+    }
+
+    const emaFast = candleEMA(this.candles, EMA_FAST_PERIOD);
+    const emaSlow = candleEMA(this.candles, EMA_SLOW_PERIOD);
+    const rsiValues = calculateRSI(this.candles, RSI_PERIOD);
+    const rsi = rsiValues[rsiValues.length -1] ?? null;
+    const bb = bollingerBands(this.candles, BB_PERIOD, BB_STDDEV);
+    const atrValues = calculateATR(this.candles, ATR_PERIOD);
+    const atr = atrValues[atrValues.length -1] ?? null;
+
+    const payload: IndicatorDataSet = {
+      emaFast: isNaN(emaFast) ? null : emaFast,
+      emaSlow: isNaN(emaSlow) ? null : emaSlow,
+      rsi: rsi ?? null,
+      bbUpper: isNaN(bb.upper) ? null : bb.upper,
+      bbMiddle: isNaN(bb.middle) ? null : bb.middle,
+      bbLower: isNaN(bb.lower) ? null : bb.lower,
+      atr: atr ?? null,
+      currentPrice: triggeringCandle.close,
+      timestamp: triggeringCandle.time,
+    };
+
+    orchestrator.send<IndicatorDataSet>({
+      from: 'IndicatorEngine' as AgentName,
+      type: 'INDICATORS_READY_5M',
+      payload,
+      timestamp: Date.now(),
+    });
+  }
+}
+export const indicatorEngineAgent = new IndicatorEngineAgent();

--- a/src/lib/agents/SignalGenerator.ts
+++ b/src/lib/agents/SignalGenerator.ts
@@ -1,0 +1,69 @@
+// src/lib/agents/SignalGenerator.ts
+import { orchestrator } from './Orchestrator';
+import { AgentMessage, AgentName, MessageHandler, IndicatorDataSet, TradingSignal, MarketRegime } from './types';
+import { Candle } from '@/lib/types';
+
+import { detectRegime } from '@/lib/market/regime-detector';
+import { getSignalConfluence } from '@/lib/signals/confluence-scorer';
+import { calculateTradeParams } from '@/lib/signals/price-targets';
+
+class SignalGeneratorAgent {
+  private candleHistory: Candle[] = [];
+  private readonly MAX_CANDLE_HISTORY = 50;
+
+  constructor() {
+    console.log('SignalGeneratorAgent: Constructor called. Subscribing to INDICATORS_READY_5M and candle updates.');
+    orchestrator.register('INDICATORS_READY_5M', this.onIndicatorsReady.bind(this) as MessageHandler);
+    orchestrator.register('NEW_CLOSED_CANDLE_5M', (msg: AgentMessage<Candle>) => {
+      this.candleHistory.push(msg.payload);
+      if (this.candleHistory.length > this.MAX_CANDLE_HISTORY) {
+        this.candleHistory.shift();
+      }
+    } as MessageHandler);
+    orchestrator.register('INITIAL_CANDLES_5M', (msg: AgentMessage<Candle[]>) => {
+      this.candleHistory = [...msg.payload].sort((a,b)=>a.time-b.time).slice(-this.MAX_CANDLE_HISTORY);
+    } as MessageHandler);
+  }
+
+  private onIndicatorsReady(msg: AgentMessage<IndicatorDataSet>): void {
+    const indicators = msg.payload;
+
+    if (!indicators.atr) {
+      console.warn('SignalGeneratorAgent: ATR is missing from indicators. Cannot calculate SL/TP accurately. Ensure IndicatorEngine provides ATR.');
+    }
+
+    const marketRegime: MarketRegime = detectRegime(indicators, this.candleHistory) || 'undefined';
+    const confluence = getSignalConfluence(indicators, marketRegime);
+
+    let sltp = { stopLoss: undefined as number | undefined, takeProfit: undefined as number | undefined };
+    if (confluence.action !== 'HOLD' && indicators.currentPrice && indicators.atr) {
+      sltp = calculateTradeParams({
+        entryPrice: indicators.currentPrice,
+        signalType: confluence.action,
+        atrValue: indicators.atr,
+        candles: this.candleHistory,
+        riskRewardRatio: 2,
+      });
+    }
+
+    const finalSignal: TradingSignal = {
+      action: confluence.action,
+      confidence: confluence.confidence,
+      reason: confluence.reason,
+      marketRegime,
+      entryPrice: confluence.action !== 'HOLD' ? indicators.currentPrice : undefined,
+      stopLoss: sltp.stopLoss,
+      takeProfit: sltp.takeProfit,
+      timestamp: indicators.timestamp,
+      rawIndicators: indicators,
+    };
+
+    orchestrator.send<TradingSignal>({
+      from: 'SignalGenerator' as AgentName,
+      type: 'NEW_SIGNAL_5M',
+      payload: finalSignal,
+      timestamp: Date.now(),
+    });
+  }
+}
+export const signalGeneratorAgent = new SignalGeneratorAgent();

--- a/src/lib/agents/UIAdapter.ts
+++ b/src/lib/agents/UIAdapter.ts
@@ -1,0 +1,92 @@
+// src/lib/agents/UIAdapter.ts
+import { orchestrator } from './Orchestrator';
+import { AgentMessage, AgentName, MessageHandler, AppState, TradingSignal, IndicatorDataSet } from './types';
+import { Candle } from '@/lib/types';
+
+const initialAppState: AppState = {
+  latestSignal: null,
+  candlesForChart: [],
+  latestIndicators: null,
+  dataStatus: { text: 'Initializing...', color: 'grey', lastUpdateTime: null },
+  dataError: null,
+};
+
+class UIAdapterService {
+  private state: AppState = { ...initialAppState };
+  private listeners = new Set<(state: AppState) => void>();
+
+  constructor() {
+    console.log('UIAdapterService: Initializing and subscribing to orchestrator messages.');
+
+    orchestrator.register('NEW_SIGNAL_5M', (msg: AgentMessage<TradingSignal>) => {
+      const signal = msg.payload;
+      this.updateState(s => ({ ...s, latestSignal: signal }));
+      if (typeof window !== 'undefined' && 'Notification' in window) {
+        if (signal.action !== 'HOLD' && signal.confidence >= 70) {
+          const title = `BitDash3 Signal: ${signal.action} BTC!`;
+          const body = `Reason: ${signal.reason}\nConfidence: ${signal.confidence.toFixed(1)}%`;
+          if (Notification.permission === 'granted') {
+            new Notification(title, { body, icon: '/bitcoin_icon.png' });
+          } else if (Notification.permission !== 'denied') {
+            Notification.requestPermission().then(permission => {
+              if (permission === 'granted') {
+                new Notification(title, { body, icon: '/bitcoin_icon.png' });
+              }
+            });
+          }
+        }
+      }
+    } as MessageHandler);
+
+    orchestrator.register('INITIAL_CANDLES_5M', (msg: AgentMessage<Candle[]>) =>
+      this.updateState(s => ({ ...s, candlesForChart: msg.payload.slice(-200) })) as MessageHandler
+    );
+
+    orchestrator.register('LIVE_CANDLE_UPDATE_5M', (msg: AgentMessage<Candle & {isClosed: boolean}>) => {
+      const candle = msg.payload;
+      this.updateState(s => {
+        const newCandles = [...s.candlesForChart];
+        const idx = newCandles.findIndex(c => c.time === candle.time);
+        if (idx !== -1) newCandles[idx] = candle;
+        else newCandles.push(candle);
+        return { ...s, candlesForChart: newCandles.sort((a,b)=>a.time-b.time).slice(-200) };
+      });
+    } as MessageHandler);
+
+    orchestrator.register('INDICATORS_READY_5M', (msg: AgentMessage<IndicatorDataSet>) =>
+      this.updateState(s => ({ ...s, latestIndicators: msg.payload })) as MessageHandler
+    );
+
+    orchestrator.register('DATA_STATUS_UPDATE', (msg: AgentMessage<{lastUpdateTime: number}>) => {
+      this.updateState(s => ({
+        ...s,
+        dataStatus: { ...s.dataStatus, text: '● Live', color: 'green', lastUpdateTime: msg.payload.lastUpdateTime },
+        dataError: null,
+      }));
+    } as MessageHandler);
+
+    orchestrator.register('DATA_ERROR', (msg: AgentMessage<string | {message: string}>) => {
+      const errorPayload = msg.payload;
+      const message = typeof errorPayload === 'string' ? errorPayload : errorPayload?.message;
+      this.updateState(s => ({
+        ...s,
+        dataError: message || 'Unknown error',
+        dataStatus: { ...s.dataStatus, text: `Error: ${message ? message.substring(0,30) : 'Unknown'}`, color: 'red' },
+      }));
+    } as MessageHandler);
+  }
+
+  private updateState(updater: (prevState: AppState) => AppState | Partial<AppState>) {
+    this.state = { ...this.state, ...(typeof updater === 'function' ? updater(this.state) : updater) } as AppState;
+    this.listeners.forEach(l => l(this.state));
+  }
+
+  public getState = (): AppState => this.state;
+
+  public subscribe = (listener: (state: AppState) => void): (() => void) => {
+    this.listeners.add(listener);
+    listener(this.state);
+    return () => this.listeners.delete(listener);
+  };
+}
+export const uiAdapter = new UIAdapterService();

--- a/src/lib/agents/types.ts
+++ b/src/lib/agents/types.ts
@@ -1,5 +1,14 @@
 // src/lib/agents/types.ts
-export type AgentName = 'DataCollector' | 'IndicatorEngine' | 'SignalGenerator' | 'Orchestrator' | 'UI' | 'BasicCandleDisplay' | 'AgentInitializer';
+import { Candle } from '@/lib/types';
+export type AgentName =
+  | 'DataCollector'
+  | 'IndicatorEngine'
+  | 'SignalGenerator'
+  | 'Orchestrator'
+  | 'UI'
+  | 'BasicCandleDisplay'
+  | 'AgentInitializer'
+  | 'DataFreshnessIndicator';
 
 export interface AgentMessage<T = any> {
   from: AgentName;
@@ -9,3 +18,42 @@ export interface AgentMessage<T = any> {
 }
 
 export type MessageHandler<T = any> = (message: AgentMessage<T>) => void;
+
+export interface IndicatorDataSet {
+  emaFast: number | null;
+  emaSlow: number | null;
+  rsi: number | null;
+  bbUpper: number | null;
+  bbMiddle: number | null;
+  bbLower: number | null;
+  atr: number | null;
+  currentPrice: number;
+  timestamp: number;
+}
+
+export type MarketRegime =
+  | 'trending-up'
+  | 'trending-down'
+  | 'ranging'
+  | 'volatile'
+  | 'undefined';
+
+export interface TradingSignal {
+  action: 'BUY' | 'SELL' | 'HOLD';
+  confidence: number;
+  reason: string;
+  marketRegime: MarketRegime;
+  entryPrice?: number;
+  stopLoss?: number;
+  takeProfit?: number;
+  timestamp: number;
+  rawIndicators?: IndicatorDataSet;
+}
+
+export interface AppState {
+  latestSignal: TradingSignal | null;
+  candlesForChart: Candle[];
+  latestIndicators: IndicatorDataSet | null;
+  dataStatus: { text: string; color: string; lastUpdateTime: number | null };
+  dataError: string | null;
+}

--- a/src/lib/market/regime-detector.ts
+++ b/src/lib/market/regime-detector.ts
@@ -450,3 +450,15 @@ export class MarketRegimeDetector {
     return Date.now() - this.lastRegimeChange;
   }
 }
+
+export function detectRegime(indicators: import('../agents/types').IndicatorDataSet, candles: Candle[]): import('../agents/types').MarketRegime {
+  if (!indicators.emaFast || !indicators.emaSlow) return 'undefined';
+  const diff = (indicators.emaFast - indicators.emaSlow) / indicators.emaSlow;
+  if (Math.abs(diff) < 0.001) return 'ranging';
+
+  if (indicators.atr && indicators.atr / indicators.currentPrice > 0.02) {
+    return 'volatile';
+  }
+
+  return diff > 0 ? 'trending-up' : 'trending-down';
+}

--- a/src/lib/signals/confluence-scorer.ts
+++ b/src/lib/signals/confluence-scorer.ts
@@ -272,3 +272,21 @@ export class ConfluenceScorer {
     };
   }
 }
+
+import { IndicatorDataSet } from '../agents/types';
+
+export function getSignalConfluence(indicators: IndicatorDataSet, regime: MarketRegime): { action: 'BUY' | 'SELL' | 'HOLD'; confidence: number; reason: string } {
+  if (!indicators.emaFast || !indicators.emaSlow || !indicators.rsi) {
+    return { action: 'HOLD', confidence: 0, reason: 'Insufficient indicators' };
+  }
+
+  if (indicators.emaFast > indicators.emaSlow && indicators.rsi > 55) {
+    return { action: 'BUY', confidence: 70, reason: 'EMA fast above slow and RSI >55' };
+  }
+
+  if (indicators.emaFast < indicators.emaSlow && indicators.rsi < 45) {
+    return { action: 'SELL', confidence: 70, reason: 'EMA fast below slow and RSI <45' };
+  }
+
+  return { action: 'HOLD', confidence: 50, reason: 'No strong signal' };
+}

--- a/src/lib/signals/price-targets.ts
+++ b/src/lib/signals/price-targets.ts
@@ -1,0 +1,25 @@
+import { Candle } from '@/lib/types';
+
+interface Params {
+  entryPrice: number;
+  signalType: 'BUY' | 'SELL';
+  atrValue: number;
+  candles?: Candle[];
+  riskRewardRatio?: number;
+}
+
+export function calculateTradeParams(params: Params): { stopLoss?: number; takeProfit?: number } {
+  const { entryPrice, signalType, atrValue, riskRewardRatio = 2 } = params;
+  if (!atrValue || atrValue <= 0) return {};
+  const distance = atrValue * 1.5;
+  if (signalType === 'BUY') {
+    return {
+      stopLoss: entryPrice - distance,
+      takeProfit: entryPrice + distance * riskRewardRatio,
+    };
+  }
+  return {
+    stopLoss: entryPrice + distance,
+    takeProfit: entryPrice - distance * riskRewardRatio,
+  };
+}


### PR DESCRIPTION
## Summary
- update DataCollector to emit `DATA_STATUS_UPDATE`
- simplify and integrate `DataFreshnessIndicator` with app state
- add `SignalDisplay` component and wire to dashboard
- define IndicatorEngine and SignalGenerator agents
- create UIAdapter service and shared state hook

## Testing
- `npm test` *(fails: MarketRegimeDetector and others)*
- `npm run lint` *(fails: lint errors across project)*

------
https://chatgpt.com/codex/tasks/task_b_684efc5646b88323a7640d57881784c1